### PR TITLE
E0 remapping corrected + added Unicomp New Model M Pause/Break key workaround

### DIFF
--- a/keyboards/converter/ibmpc_usb/config.h
+++ b/keyboards/converter/ibmpc_usb/config.h
@@ -22,8 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x6536
 #define DEVICE_VER      0x0101
 #define MANUFACTURER    QMK
-#define PRODUCT         Legacy Keyboard Convert
-#define DESCRIPTION     convert IBM PC keyboard to USB
+#define PRODUCT         IBM keyboard protocol converter
 
 /* matrix size */
 #define MATRIX_ROWS 8

--- a/keyboards/converter/ibmpc_usb/matrix.c
+++ b/keyboards/converter/ibmpc_usb/matrix.c
@@ -801,14 +801,23 @@ static int8_t process_cs1(uint8_t code)
 static uint8_t cs2_e0code(uint8_t code) {
     switch(code) {
         // E0 prefixed codes translation See [a].
-        case 0x11: return 0x0F; // right alt
-        case 0x14: return 0x17; // right control
-        case 0x1F: return 0x19; // left GUI
+        case 0x11:  if (0xAB90 == keyboard_id || 0xAB91 == keyboard_id)
+                        return 0x13; // Hiragana(5576) -> KANA
+                    else
+                        return 0x0F; // right alt
+
+        case 0x41:  if (0xAB90 == keyboard_id || 0xAB91 == keyboard_id)
+                        return 0x7C; // Keypad ,(5576) -> Keypad *
+                    else
+                        return (code & 0x7F);
+
+        case 0x14: return 0x19; // right control
+        case 0x1F: return 0x17; // left GUI
         case 0x27: return 0x1F; // right GUI
-        case 0x2F: return 0x5C; // apps
+        case 0x2F: return 0x27; // apps
         case 0x4A: return 0x60; // keypad /
         case 0x5A: return 0x62; // keypad enter
-        case 0x69: return 0x27; // end
+        case 0x69: return 0x5C; // end
         case 0x6B: return 0x53; // cursor left
         case 0x6C: return 0x2F; // home
         case 0x70: return 0x39; // insert

--- a/keyboards/converter/ibmpc_usb/matrix.c
+++ b/keyboards/converter/ibmpc_usb/matrix.c
@@ -825,6 +825,7 @@ static uint8_t cs2_e0code(uint8_t code) {
         case 0x72: return 0x3F; // cursor down
         case 0x74: return 0x47; // cursor right
         case 0x75: return 0x4F; // cursor up
+        case 0x77: return 0x00; // Unicomp New Model M Pause/Break key fix
         case 0x7A: return 0x56; // page down
         case 0x7D: return 0x5E; // page up
         case 0x7C: return 0x7F; // Print Screen


### PR DESCRIPTION
- Some keys were mapping incorrectly (End <-> Apps, LGUI <-> RCtrl etc.) due to inconsistent cs2_e0code() compared to the rest of the files. Now corrected and tested on 2021 Unicomp New Model M and 1990 IBM p/n 1391406.
- Removed DESCRIPTION from config.h as this is not supported any more and is therefore causing annoying build warnings.
- Added workaround for faulty Pause/Break key logic on Unicomp New Model M (they have it spitting out a non-standard sequence when Ctrl is held - E0 77 - which is effectively emulating Num Lock... but that's just a different version of Pause, when it should be Break)